### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-#zbx_nginx_template
+# zbx_nginx_template
 
 Zabbix template for Nginx (python)
 
 It's accumulate nginx stats and parse the access.log (just pice of log at once) and push result in Zabbix through trap-messages
 
-##System requirements
+## System requirements
 
 - [python](http://www.python.org/downloads/)
 - [nginx](http://nginx.org/) with configured http_stub_status_module and access.log


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
